### PR TITLE
Fix: Update ContentSearch.vue to export csv

### DIFF
--- a/src/router/views/admin/Reports/ContentSearch.vue
+++ b/src/router/views/admin/Reports/ContentSearch.vue
@@ -192,7 +192,7 @@
             <template v-slot:footer.prepend>
               <v-btn
                 small
-                @click.stop="generateDownload({ type: 'xls' })"
+                @click.stop="generateDownload({ type: 'csv' })"
                 :loading="isDownloading"
                 :disabled="isDownloading || fileDownloadBtn.disabled || reportData.length === 0"
                 :color="fileDownloadBtn.color"


### PR DESCRIPTION
Previously exporting as xls, which resulted in 255 character truncation of sentence content column